### PR TITLE
MNT: Ensure CutTools is a run requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,12 +16,11 @@ source:
 build:
   # FIXME: mg5amcnlo doesn't support Python 3.12 yet
   skip: true  # [py<37 or py>311 or win]
-  number: 1
+  number: 2
   script:
     # Remove unnecessary files
     - rm -r source/.github
     - rm -r source/tests
-    - rm -r source/vendor/CutTools
     - rm source/.bzrignore
     - rm source/.gitignore
     - rm source/code-notes
@@ -84,6 +83,7 @@ requirements:
     - fortran-compiler
     - make
     - tar
+    - wget  # for madgraph install command
     - perl
     - python
     - six
@@ -92,6 +92,7 @@ requirements:
     - emela
     - lhapdf
     - ply
+    - cuttools-static
     - oneloop
     # ninja-hep-ph uses libquadmath and so does not support macOS or aarch64
     - ninja-hep-ph  # [linux and (x86_64 or ppc64le)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -94,6 +94,8 @@ requirements:
     - ply
     - cuttools-static
     - oneloop
+    - mpfun90
+    - qcdloop-fortran-static
     # ninja-hep-ph uses libquadmath and so does not support macOS or aarch64
     - ninja-hep-ph  # [linux and (x86_64 or ppc64le)]
     - collier


### PR DESCRIPTION
* Add cuttools-static, mpfun90, and qcdloop-fortran-static as run requirements.
* Add wget for if user needs to run install inside of MadGraph.
* Temporarily remove the deletion of vendored CutTools.
* Bump build number.

Related to Issue https://github.com/conda-forge/mg5amcnlo-feedstock/issues/3

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
