### PR TITLE
FIX: Use mg5amcnlo-pythia8-interface for MG5aMC_PY8_interface

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -2,14 +2,10 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '8'
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -2,14 +2,10 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '8'
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_aarch64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpython.yaml
@@ -2,14 +2,10 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '8'
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -2,14 +2,10 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '8'
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
@@ -2,14 +2,10 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '8'
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
@@ -2,14 +2,10 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '8'
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -10,8 +10,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '8'
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -10,8 +10,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '8'
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -10,8 +10,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '8'
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -10,8 +10,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '8'
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,8 +31,6 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
-curl -fsSL https://pixi.sh/install.sh | bash
-export PATH="~/.pixi/bin:$PATH"
 pushd "${FEEDSTOCK_ROOT}"
 arch=$(uname -m)
 if [[ "$arch" == "x86_64" ]]; then

--- a/README.md
+++ b/README.md
@@ -198,12 +198,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -230,7 +230,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/mg5amcnlo-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,7 +7,7 @@
 
 [project]
 name = "mg5amcnlo-feedstock"
-version = "3.52.2"  # conda-smithy version used to generate this file
+version = "3.52.3"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/mg5amcnlo-feedstock"
 authors = ["@conda-forge/mg5amcnlo"]
 channels = ["conda-forge"]

--- a/recipe/mg5_configuration.txt
+++ b/recipe/mg5_configuration.txt
@@ -43,7 +43,7 @@ f2py_compiler_py3 = REPLACE_WITH_PREFIX/bin/f2py
 #! Prefered C++ Compiler
 #! If None: try to find g++ or clang on the system
 #!
-cpp_compiler = REPLACE_WITH_PREFIX/bin/REPLACE_WITH_BASENAME_GXX
+cpp_compiler = REPLACE_WITH_PREFIX/bin/REPLACE_WITH_BASENAME_CXX
 
 #! Prefered Text Editor
 #!  Default: use the shell default Editor

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -283,13 +283,13 @@ tests:
       # c.f. https://github.com/mg5amcnlo/mg5amcnlo/issues/194
       - test ! -f ME5_debug
 
-      - if: build_platform == target_platform
+      # c.f. https://github.com/conda-forge/mg5amcnlo-feedstock/issues/3
+      - if: (build_platform == target_platform) and not (osx and x86_64)
         then:
           - lhapdf install NNPDF23_nlo_as_0119_qed &> download_log.txt
           - echo -e "\n# Running tutorial_amc-at-nlo.mg5"
           - mg5_aMC ./tutorial_amc-at-nlo.mg5
           - ls -lhtra
-          # c.f. https://github.com/conda-forge/mg5amcnlo-feedstock/issues/3
           - test ! -f ME5_debug
 
 about:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -207,6 +207,8 @@ requirements:
     - lhapdf
     - ply
     - bc  # Needed to run showering
+    - if: linux
+      then: procps-ng  # Needed for pgrep in madgraph/various/cluster.py
     # MG5_aMC/vendor/ libraries
     - oneloop-static
     - iregi-static 1.1.0.*

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -19,7 +19,7 @@ source:
 
 build:
   # FIXME: mg5amcnlo doesn't support Python 3.12 yet
-  number: 5
+  number: 6
   skip: match(python, "<3.7") or match(python, ">3.11") or win
   script:
     # Remove unnecessary files
@@ -117,27 +117,6 @@ build:
     - ln -s $PREFIX/include/collier.mod $PREFIX/MG5_aMC/HEPTools/collier/include/
     - ln -s $PREFIX/include/collier.mod $PREFIX/MG5_aMC/HEPTools/include/
 
-    # Add MG5aMC_PY8_interface
-    # https://github.com/mg5amcnlo/MG5aMC_PY8_interface
-
-    # Need the CXX in Makefile.inc to be available _during_ the build, and so
-    # need to inject the $BUILD_PREFIX CXX, but restore to the $PREFIX CXX
-    # after so that at runtime the correct CXX is used.
-    - cp $PREFIX/share/Pythia8/examples/Makefile.inc $PREFIX/share/Pythia8/examples/Makefile.inc.bak
-    - sed -i "s|CXX=$PREFIX|CXX=$BUILD_PREFIX|" $PREFIX/share/Pythia8/examples/Makefile.inc
-    - curl -sL https://github.com/mg5amcnlo/MG5aMC_PY8_interface/archive/5d82df1b77bd2b69ffeae5b6bfe100a62b31c30e.tar.gz | tar -xz
-    - mv MG5aMC_PY8_interface-5d82df1b77bd2b69ffeae5b6bfe100a62b31c30e MG5aMC_PY8_interface
-    - cd MG5aMC_PY8_interface
-    - echo -e "\n# Compiling MG5aMC_PY8_interface"
-    - python compile.py $PREFIX
-    - mkdir -p $PREFIX/MG5_aMC/HEPTools/MG5aMC_PY8_interface
-    - cd ..
-    # TODO: Determine the minimum required set of files to install
-    - cp MG5aMC_PY8_interface/* $PREFIX/MG5_aMC/HEPTools/MG5aMC_PY8_interface/
-    - rm -rf MG5aMC_PY8_interface
-
-    # Restore Makefile.inc
-    - mv $PREFIX/share/Pythia8/examples/Makefile.inc.bak $PREFIX/share/Pythia8/examples/Makefile.inc
     # Build configuration file be replacing placeholder values with PREFIX
     - echo -e "\n# Configuring $PREFIX/MG5_aMC/input/mg5_configuration.txt"
     - cp $RECIPE_DIR/mg5_configuration.txt .
@@ -181,18 +160,17 @@ requirements:
   build:
     - ${{ stdlib('c') }}
     # Compilers needed to set names in mg5_configuration.txt and will be
-    # used in the future along with make when bugs with Pythia8 are fixed
+    # used in the future along with make
     - ${{ compiler('cxx') }}
     - ${{ compiler('fortran') }}
     - make
     - if: build_platform != target_platform
       then:
+        # Need cross-python to be able to use Python libraries
         - cross-python_${{ target_platform }}
         - python
     - sed
     - grep
-    - curl  # for downloading MG5aMC_PY8_interface
-    - tar  # for extracting MG5aMC_PY8_interface
   host:
     - python
     - six
@@ -208,7 +186,6 @@ requirements:
     - if: linux and (x86_64 or ppc64le)
       then: ninja-hep-ph-static 1.1.*
     - collier-static
-    - pythia8 8.311.*
     - hepmc2
     - hepmc3
   run:
@@ -217,7 +194,8 @@ requirements:
     - fortran-compiler
     - make
     - tar
-    - wget  # for madgraph install command
+    - wget  # for import_model_from_db in models/import_ufo.py
+    - curl  # for import_model_from_db in models/import_ufo.py
     - perl
     - python
     - six
@@ -239,12 +217,11 @@ requirements:
     - if: linux and (x86_64 or ppc64le)
       then: ninja-hep-ph-static 1.1.*
     - collier-static
-    # mg5amcnlo v3.5.7 requires pythia v8.311 for MG5aMC_PY8_interface to work
-    # without edits to compile.py
-    - pythia8 8.311.*
+    # c.f. https://github.com/conda-forge/mg5amcnlo-pythia8-interface-feedstock/issues/2
+    - if: not (osx and x86_64)
+      then: mg5amcnlo-pythia8-interface
     - hepmc2
     - hepmc3
-    - libzlib  # Needed by MG5aMC_PY8_interface
     - ghostscript
     - gnuplot
 
@@ -278,18 +255,6 @@ tests:
         - MG5_aMC/vendor/StdHEP/lib/libstdhep.a
         - MG5_aMC/vendor/StdHEP/lib/libstdhepC.a
         - MG5_aMC/vendor/StdHEP/lib/libFmcfio.a
-
-        - MG5_aMC/HEPTools/MG5aMC_PY8_interface/COMPATIBILITY
-        - MG5_aMC/HEPTools/MG5aMC_PY8_interface/MG5AMC_VERSION_ON_INSTALL
-        - MG5_aMC/HEPTools/MG5aMC_PY8_interface/MG5aMC_PY8_interface
-        - MG5_aMC/HEPTools/MG5aMC_PY8_interface/Makefile_mg5amc_py8_interface_static
-        - MG5_aMC/HEPTools/MG5aMC_PY8_interface/MultiHist.h
-        - MG5_aMC/HEPTools/MG5aMC_PY8_interface/PYTHIA8_VERSION_ON_INSTALL
-        - MG5_aMC/HEPTools/MG5aMC_PY8_interface/SyscalcVeto.h
-        - MG5_aMC/HEPTools/MG5aMC_PY8_interface/VERSION
-        - MG5_aMC/HEPTools/MG5aMC_PY8_interface/get_pythia8_version.py
-        - MG5_aMC/HEPTools/MG5aMC_PY8_interface/make_tarball.py
-        - MG5_aMC/HEPTools/MG5aMC_PY8_interface/pythia8_version.cc
       bin:
         - mg5_aMC
   - files:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -121,8 +121,10 @@ build:
     - echo -e "\n# Configuring $PREFIX/MG5_aMC/input/mg5_configuration.txt"
     - cp $RECIPE_DIR/mg5_configuration.txt .
     - sed -i "s|REPLACE_WITH_PREFIX|$PREFIX|g" mg5_configuration.txt
-    - sed -i "s|REPLACE_WITH_BASENAME_FC|$(basename $FC)|g" mg5_configuration.txt
-    - sed -i "s|REPLACE_WITH_BASENAME_GXX|$(basename $GXX)|g" mg5_configuration.txt
+    # Ensure that the HOST compiler names that will be used at runtime are included
+    # (needed for cross-compilation)
+    - sed -i "s|REPLACE_WITH_BASENAME_FC|$(basename ${FC_FOR_BUILD//$BUILD/$HOST})|g" mg5_configuration.txt
+    - sed -i "s|REPLACE_WITH_BASENAME_CXX|$(basename ${CXX_FOR_BUILD//$BUILD/$HOST})|g" mg5_configuration.txt
     # c.f. https://github.com/conda-forge/mg5amcnlo-feedstock/issues/13
     - sed -i "s|# automatic_html_opening = True|automatic_html_opening = False|g" mg5_configuration.txt
     # Ninja settings in mg5_configuration.txt


### PR DESCRIPTION
Partially addresses Issue #7 (requires https://github.com/conda-forge/mg5amcnlo-pythia8-interface-feedstock/pull/4 also)

**FIX: Use mg5amcnlo-pythia8-interface for MG5aMC_PY8_interface**

* Add `mg5amcnlo-pythia8-interface` as a `run` requirement, which supplies the Pythia8 interface program and defines `pythia8` `run` requirements.
   - Skip `mg5amcnlo-pythia8-interface` for `osx-64` given `PY8_parallelization` splitting bug.
   - c.f. https://github.com/conda-forge/mg5amcnlo-pythia8-interface-feedstock/issues/2
* Remove build information for MG5aMC_PY8_interface and remove file checks.
* Bump build number.

**FIX: Use target platform compiler names in mg5_configuration.txt**

* Use `CXX_FOR_BUILD` and `FF_FOR_BUILD` to get the correct compilers that for the runtime target platform (the host platform). The '_FOR_BUILD' compilers give the build platform compilers, but with the correct name prefaced by the `BUILD` triplet (e.g. `x86_64-conda-linux-gnu`).
   - c.f. https://conda-forge.org/blog/2020/10/29/macos-arm64/#how-to-add-a-osx-arm64-build-to-a-feedstock
* Ensure that the `HOST` compiler names that will be used at runtime are included (needed for cross-compilation) by replacing the `BUILD` values with `HOST` values in the compiler basenames in mg5_configuration.txt.

**MNT: Add procps-ng for linux for pgrep**

* Add `procps-ng` as a run requirement for linux platforms to provide pgrep for use in `madgraph/various/cluster.py`.
    - `procps-ng` is not available for `osx` platforms.
    - c.f. https://github.com/conda-forge/procps-ng-feedstock/issues/15
    - `madgraph/various/cluster.py` is used in Pythia8 related code.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
